### PR TITLE
The analyser actually uses the $TARGET_NAME in its paths as opposed t…

### DIFF
--- a/TreatAnalyzerWarningsAsError.sh
+++ b/TreatAnalyzerWarningsAsError.sh
@@ -35,7 +35,7 @@ function verify_clang_analysis_at_path()
 function verify_clang_analysis_for_object_file()
 {
   local object_file=$1
-  local analysis_directory=$TARGET_TEMP_DIR/StaticAnalyzer/$PROJECT_NAME/$PRODUCT_NAME/$CURRENT_VARIANT/$analyzer_arch
+  local analysis_directory=$TARGET_TEMP_DIR/StaticAnalyzer/$PROJECT_NAME/$TARGET_NAME/$CURRENT_VARIANT/$analyzer_arch
   local analysis_path=$analysis_directory/${object_file%.*}.plist
 
   # if this object file corresponds to a source file that clang analyzed...


### PR DESCRIPTION
…o the $PRODUCT_NAME.  In most scenario's $PRODUCT_NAME is the same as $TARGET_NAME which is why this probably hasn't been flagged before but for our needs I've had to change to $TARGET_NAME and I thought I'd contribute this back to the project.
